### PR TITLE
Use `transactSmartWallet`

### DIFF
--- a/app/collect/route.tsx
+++ b/app/collect/route.tsx
@@ -14,14 +14,14 @@ export async function POST(request: NextRequest) {
     const { spendPermission, signature } = body;
 
     // transact with EOA or Smart Wallet, make sure to update NEXT_PUBLIC_SPENDER_ADDRESS variable in accordance with choice
-    // const { success, transactionHash } = await transactSmartWallet(
-    //   spendPermission,
-    //   signature
-    // );
-    const { success, transactionHash } = await transactEOA(
+    const { success, transactionHash } = await transactSmartWallet(
       spendPermission,
       signature
     );
+    // const { success, transactionHash } = await transactEOA(
+    //   spendPermission,
+    //   signature
+    // );
 
     return NextResponse.json({
       status: success ? "success" : "failure",


### PR DESCRIPTION
Trying to unbreak the hosted demo app, which I think might use a smart wallet spender.